### PR TITLE
Fix screenshot path validation issue in add_game_to_file

### DIFF
--- a/src/miscore/record_data.py
+++ b/src/miscore/record_data.py
@@ -273,14 +273,27 @@ class RecordData(BaseModel):
             )
             record_data = RecordData(games=[new_game])
 
-        # Validate the new data structure before saving
-        # This will raise an exception if invalid, preventing file corruption
-        validated_data = RecordData(**record_data.model_dump())
+        # Maintain working directory context for FilePath validation
+        # This ensures relative screenshot paths are validated correctly
+        old_wd = os.getcwd()
+        current_directory = os.path.dirname(os.path.abspath(filename))
+        if current_directory:
+            os.chdir(current_directory)
 
-        # Only save if validation passes
-        validated_data.save(filename)
+        try:
+            # Validate the new data structure before saving
+            # This will raise an exception if invalid, preventing file corruption
+            validated_data = RecordData(**record_data.model_dump())
 
-        return True
+            # Only save if validation passes
+            validated_data.save(
+                os.path.basename(filename) if current_directory else filename
+            )
+
+            return True
+        finally:
+            if current_directory:
+                os.chdir(old_wd)
 
     @classmethod
     def _create_game_interactive(cls, game_name):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1330,6 +1330,7 @@ class TestInteractiveInputValidation:
             if os.path.exists(temp_filename):
                 os.unlink(temp_filename)
 
+
 def test_add_game_with_existing_screenshot_paths():
     """Test that add_game_to_file works with existing records that have screenshot paths"""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as temp_file:
@@ -1337,9 +1338,7 @@ def test_add_game_with_existing_screenshot_paths():
 
     # Create a test screenshot file relative to the temp file directory
     screenshot_path = "test_screenshot.png"
-    full_screenshot_path = os.path.join(
-        os.path.dirname(temp_filename), screenshot_path
-    )
+    full_screenshot_path = os.path.join(os.path.dirname(temp_filename), screenshot_path)
 
     try:
         # Create the screenshot file
@@ -1380,7 +1379,9 @@ def test_add_game_with_existing_screenshot_paths():
         result = RecordData.add_game_to_file(
             "Second Game", temp_filename, interactive=False
         )
-        assert result is True, "Failed to add game to file with existing screenshot paths"
+        assert (
+            result is True
+        ), "Failed to add game to file with existing screenshot paths"
 
         # Verify both games are present
         loaded_data = RecordData.load(temp_filename)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1329,3 +1329,72 @@ class TestInteractiveInputValidation:
         finally:
             if os.path.exists(temp_filename):
                 os.unlink(temp_filename)
+
+def test_add_game_with_existing_screenshot_paths():
+    """Test that add_game_to_file works with existing records that have screenshot paths"""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as temp_file:
+        temp_filename = temp_file.name
+
+    # Create a test screenshot file relative to the temp file directory
+    screenshot_path = "test_screenshot.png"
+    full_screenshot_path = os.path.join(
+        os.path.dirname(temp_filename), screenshot_path
+    )
+
+    try:
+        # Create the screenshot file
+        with open(full_screenshot_path, "w") as f:
+            f.write("fake screenshot")
+
+        # Create initial file with a game that has a record with a screenshot
+        from miscore.record_data import (
+            RecordType,
+            CompletedRecordEntry,
+        )
+
+        # Change to the temp file directory (so FilePath validation works for relative paths)
+        old_wd = os.getcwd()
+        temp_dir = os.path.dirname(temp_filename)
+        if temp_dir:
+            os.chdir(temp_dir)
+
+        try:
+            # Create a record with a relative screenshot path
+            record_with_screenshot = CompletedRecordEntry(
+                date=date.today(), screenshot=screenshot_path
+            )
+
+            completed_rt = RecordType(
+                name="Completion", type="completed", records=[record_with_screenshot]
+            )
+            initial_game = Game(name="Initial Game", record_types=[completed_rt])
+            record_data = RecordData(games=[initial_game])
+
+            # Save the file
+            record_data.save(os.path.basename(temp_filename))
+        finally:
+            os.chdir(old_wd)
+
+        # Now try to add a new game from a different directory
+        # This should work even though we're not in the temp file's directory
+        result = RecordData.add_game_to_file(
+            "Second Game", temp_filename, interactive=False
+        )
+        assert result is True, "Failed to add game to file with existing screenshot paths"
+
+        # Verify both games are present
+        loaded_data = RecordData.load(temp_filename)
+        assert len(loaded_data.games) == 2
+        game_names = [game.name for game in loaded_data.games]
+        assert "Initial Game" in game_names
+        assert "Second Game" in game_names
+
+        # Verify the screenshot path is still valid
+        first_game = next(g for g in loaded_data.games if g.name == "Initial Game")
+        assert first_game.record_types[0].records[0].screenshot.name == screenshot_path
+
+    finally:
+        if os.path.exists(temp_filename):
+            os.unlink(temp_filename)
+        if os.path.exists(full_screenshot_path):
+            os.unlink(full_screenshot_path)


### PR DESCRIPTION
When add_game_to_file() validated existing records with relative screenshot paths,
it would fail because validation occurred from the wrong working directory. This fix
ensures the method changes to the JSON file's directory before validation, matching
the pattern already used in add_record_to_file().

- Updated add_game_to_file to change working directory before validation
- Added test case to reproduce and verify the fix
- All existing tests continue to pass